### PR TITLE
add module configuration page and use config instead of static variab…

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,12 @@
 ## Description ##
 
 Permet de mettre en place un système de parrainage (ou d'affiliation) appelé `code privilège`.  
-D'un côté, on a les "parrains", appelés "parrains particuliers" s'ils sont particuliers ou "parrains pro" s'ils sont professionnels (on peut aussi dire "commerciaux").  
-Les clients s'inscrivent avec un code privilège qui correspond au code d'un parrain. Le parrain touchera des commissions sur toutes les ventes effectuées avec son code privilège.  
-Le parrain doit être placé (manuellement) dans le groupe `Parrain pro` pour un professionnel, après validation de son identité.  
-Le parrain doit être placé (manuellement) dans le groupe `Parrain particulier` pour un particulier, après validation de son identité.  
-Le client privilégié doit être placé (manuellement) dans le groupe `Client privilégié`, après vérification de son code privilège.  
-Le client peut aussi être un professionnel. Dans ce cas, il doit être placé (manuellement) dans le groupe `Professionnel privilégié`, après vérification de son code privilège.  
-Il faut indiquer dans la configuration du module quel group joue le rôle du groupe `Parrains Pro` et quel groupe joue le rôle de `Parrain particulier`  
+D'un côté, on a les "responsables des ventes" ou commerciaux.
+Les clients s'inscrivent avec un code privilège qui correspond au code privilège du responsable des ventes. Le parrain touchera des commissions sur toutes les ventes effectuées avec son code privilège.  
+Le parrain doit être placé (manuellement) dans le groupe `Commercial` pour un professionnel, après validation de son identité.  
+Le client privilégié sera placé (automatiqument) dans le groupe `Client privilégié`, si son code privilège correpond bien à celui de son responsable des ventes.  
+Le client peut aussi être un professionnel. Dans ce cas, il doit être placé (manuellement) dans le groupe `Professionnel privilégié`, après vérification de son code privilège et de son SIREN.  
+Il faut indiquer dans la configuration du module quel group joue le rôle du groupe `Parrains Pro`  
 
 ## versions PrestaShop Supportées ##
 
@@ -39,6 +38,9 @@ Il faut indiquer dans la configuration du module quel group joue le rôle du gro
 
 
 ## Historique des versions ##
+### v 1.2.3  ###
+- Finalement pour les affiliés on s'inscrit via un site externe. On retire donc la case à cocher du formulaire d'inscription pour le remplacer par une case à cocher pour devenir responsable des ventes
+
 ### v 1.2.2  ###
 - Correction du bug qui ne permettait plus de modifier un client
 

--- a/sql/install.php
+++ b/sql/install.php
@@ -33,7 +33,7 @@ $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'sbu_privilege_code` (
     `id_privilege_code` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
     `id_customer` INT(10) UNSIGNED NOT NULL,
     `privilege_code` VARCHAR(50) NULL DEFAULT NULL,
-    `private_sponsor` TINYINT NOT NULL DEFAULT 0,
+    `sales_manager` TINYINT NOT NULL DEFAULT 0,
     PRIMARY KEY  (`id_privilege_code`)
 ) ENGINE=' . _MYSQL_ENGINE_ . ' DEFAULT CHARSET=utf8;';
 

--- a/src/Entity/PrivilegeCode.php
+++ b/src/Entity/PrivilegeCode.php
@@ -27,13 +27,18 @@ class PrivilegeCode extends ObjectModel
      */
     public $privilege_code;
 
+    /**
+     * @var int
+     */
+    public $sales_manager;
+
     public static $definition = [
         'table' => 'sbu_privilege_code',
         'primary' => 'id_privilege_code',
         'fields' => [
             'id_customer' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt'],
             'privilege_code' => ['type' => self::TYPE_STRING, 'validate' => 'isGenericName', 'size' => 45],
-            'private_sponsor' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt'],
+            'sales_manager' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt'],
         ],
     ];
 }

--- a/src/Repository/PrivilegeCodeRepository.php
+++ b/src/Repository/PrivilegeCodeRepository.php
@@ -58,7 +58,7 @@ class PrivilegeCodeRepository
     }
 
     /**
-     * Gets allowed to review status by customer.
+     * Gets privilege code by customer.
      *
      * @param int $customerId
      *
@@ -77,5 +77,27 @@ class PrivilegeCodeRepository
         $queryBuilder->setParameter('customer_id', $customerId);
 
         return (string) $queryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * Gets sales manager by customer.
+     *
+     * @param int $customerId
+     *
+     * @return int
+     */
+    public function getSalesManager($customerId)
+    {
+        $queryBuilder = $this->connection->createQueryBuilder();
+
+        $queryBuilder
+            ->select('`sales_manager`')
+            ->from($this->dbPrefix . 'sbu_privilege_code')
+            ->where('`id_customer` = :customer_id')
+        ;
+
+        $queryBuilder->setParameter('customer_id', $customerId);
+
+        return (int) $queryBuilder->execute()->fetch(PDO::FETCH_COLUMN);
     }
 }

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -2,17 +2,13 @@
 
 global $_MODULE;
 $_MODULE = array();
-
 $_MODULE['<{sbu_privilege}prestashop>sbu_privilege_32a4d94fe40291ae21f8e2d1ae990a07'] = 'Gestion des Codes Privilèges';
+$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_40f3b1ec6bd3dc6f7b6b29c0ad83e437'] = 'Gère les codes privilèges. Chaque commercial (ou responsable des ventes) reçoit (de la part du Webmaster) un code privilège. Celui-ci le donne à ses clients. Les clients, lorsqu\'ils s\'enregistrent, renseignent ce code privilège. Ce code privilège permet au commercial de recevoir les commissions sur chaque vente de ses clients. Il est préférable d\'affecter au client un groupe \"Client Privilégié\" et de positionner des règles panier pour lui accorder des réductions. La configuration du module permet de définir le group_id dans lequel sont affectés les commerciaux. Il est recommandé de choisir \"Commercial\"';
 $_MODULE['<{sbu_privilege}prestashop>sbu_privilege_2f693105c04e4dad843875050a98e79e'] = 'Êtes-vous sûr de vouloir désinstaller le module privilege? Ceci effacera définitivement tous les codes privilèges renseignés.';
-$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_9117532bea193faec02602fd6e84a208'] = 'Je souhaite devenir affilié (je certifie être majeur)';
-$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_2fd1c38103797d61123429c45ed89f26'] = 'Code Partenaire';
-$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_01bc5de997fef9bd20ece03ff8e41e8e'] = 'Parrain particulier';
-
-// A supprimer
-$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_32a4d94fe40291ae21f8e2d1ae990a07'] = 'Gestion des Codes Privilèges';
-$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_9362a55da007af3fe9f12850a898c692'] = 'Gère les codes privilèges. Chaque commercial (ou responsable des ventes) reçoit (de la part du Webmaster) un code privilège. Celui-ci le donne à ses clients. Les clients, lorsqu\'ils s\'enregistrent, renseignent ce code privilège (nouveau champ \"privilege_code\" dans la table customer). Ce code privilège permet au commercial de recevoir les commissions sur chaque vente de ses clients. Il est préférable d\\\'affecter au client un groupe \"Client Privilégié\" et de positionner des règles panier pour lui accorder des réductions. La configuration du module permet de définir le group_id dans lequel sont affectés les commerciaux. Il est recommandé de choisir \"Commercial\"';
-$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_f23aa4f4923f066c183f7888f0769a3e'] = 'Êtes-vous sûr de vouloir désinstaller le module privilege? Ceci effacera définitivement tous les codes privilèges renseignés.';
+$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_92e34313a061f4eff6704683be05b2ce'] = 'Je souhaite devenir responsable des ventes (je certifie être majeur)';
 $_MODULE['<{sbu_privilege}prestashop>sbu_privilege_2fd1c38103797d61123429c45ed89f26'] = 'Code Privilège';
-
-
+$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_8fe305b70f73eae1ac53cf0ad69f74a8'] = 'responsable des ventes';
+$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_f4f70727dc34561dfde1a3c529b6205c'] = 'Paramètres';
+$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_6a81abcbccbab2de940a625a1a65c658'] = 'Selectionnez le groupe des responsables des ventes';
+$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_00f397f02f8f207c6c631aa940eca763'] = 'Groupe des responsables des ventes';
+$_MODULE['<{sbu_privilege}prestashop>sbu_privilege_c9cc8cce247e49bae79f15173ce97354'] = 'Enregistrer';

--- a/upgrade/upgrade-1.0.1.php
+++ b/upgrade/upgrade-1.0.1.php
@@ -1,0 +1,44 @@
+<?php
+/**
+* 2007-2021 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author    PrestaShop SA <contact@prestashop.com>
+*  @copyright 2007-2021 PrestaShop SA
+*  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * This function updates your module from previous versions to the version 1.1,
+ * usefull when you modify your database, or register a new hook ...
+ * Don't forget to create one file per version.
+ */
+function upgrade_module_1_0_1($module)
+{
+    /*
+     * Do everything you want right there,
+     * You could add a column in one of your module's tables
+     */
+    error_log("upgrade upgrade_module ".$module->name." - v".$module->version);
+    return true;
+
+}

--- a/upgrade/upgrade-1.2.3.php
+++ b/upgrade/upgrade-1.2.3.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * 2007-2021 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ *  @author    PrestaShop SA <contact@prestashop.com>
+ *  @copyright 2007-2021 PrestaShop SA
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ *  International Registered Trademark & Property of PrestaShop SA
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * This function updates your module from previous versions to the version 1.1,
+ * usefull when you modify your database, or register a new hook ...
+ * Don't forget to create one file per version.
+ */
+function upgrade_module_1_2_3($module)
+{
+    /*
+     * Do everything you want right there,
+     * You could add a column in one of your module's tables
+     */
+    Configuration::updateValue('SBU_PRIVILEGE_SALES_MANAGER_GROUP_ID', Configuration::get('SBU_PRIVILEGE_COMMERCIAL_GROUP_ID'));
+    Configuration::deleteByName('SBU_PRIVILEGE_COMMERCIAL_GROUP_ID');
+
+    $sql = array();
+
+    error_log("upgrade module " . $module->name . " - v" . $module->version);
+
+    $sql[] = "ALTER TABLE `" . _DB_PREFIX_ . "sbu_privilege_code` CHANGE `private_sponsor` `sales_manager`  TINYINT NOT NULL DEFAULT 0";
+
+    foreach ($sql as $query) {
+        error_log("executing query " . $query);
+        if (Db::getInstance()->execute($query) == false) {
+            error_log("display error = " . Db::getInstance()->displayError());
+            error_log("get msg = " . Db::getInstance()->getMsgError());
+            error_log("query ko");
+            return false;
+        }
+        error_log("query ok");
+    }
+    error_log("upgrade module " . $module->name . " - v" . $module->version . " OK");
+
+    return true;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | add module configuration page and use config instead of static variable for commercial_group_id add column sales_manager and delete old column rename config var into SALES_MANAGER_GROUP_ID
| Type?         | bug fix / new feature 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop #17 

close #17 
close #10 
close #15 
close #16 
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
